### PR TITLE
Added missing install instruction to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,8 @@ Installation
        'maintenancemode.middleware.MaintenanceModeMiddleware',
    )
    
+* Add ``maintenancemode`` to your INSTALLED_APPS.
+   
 * Run manage.py syncdb to create the necessary tables.
 
 * Adding the middleware and running your site creates the necessary records in the database


### PR DESCRIPTION
Install instructions didn't mention the need to add `maintenancemode` to project's INSTALLED_APPS.
Failing to doing so will prevent the app's db entries to be properly syncd.
